### PR TITLE
fix warnings

### DIFF
--- a/gemfiles/rails_52.gemfile.lock
+++ b/gemfiles/rails_52.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     seamless_database_pool (1.0.20)
       activerecord (>= 3.2.0)
       concurrent-ruby (~> 1.0)
+      ruby2_keywords (>= 0.0.5)
 
 GEM
   remote: https://rubygems.org/
@@ -45,6 +46,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    ruby2_keywords (0.0.5)
     sqlite3 (1.4.2)
     thor (1.2.1)
     thread_safe (0.3.6)

--- a/gemfiles/rails_60.gemfile.lock
+++ b/gemfiles/rails_60.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     seamless_database_pool (1.0.20)
       activerecord (>= 3.2.0)
       concurrent-ruby (~> 1.0)
+      ruby2_keywords (>= 0.0.5)
 
 GEM
   remote: https://rubygems.org/
@@ -44,6 +45,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    ruby2_keywords (0.0.5)
     sqlite3 (1.4.2)
     thor (1.2.1)
     thread_safe (0.3.6)

--- a/gemfiles/rails_61.gemfile.lock
+++ b/gemfiles/rails_61.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     seamless_database_pool (1.0.20)
       activerecord (>= 3.2.0)
       concurrent-ruby (~> 1.0)
+      ruby2_keywords (>= 0.0.5)
 
 GEM
   remote: https://rubygems.org/
@@ -44,6 +45,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    ruby2_keywords (0.0.5)
     sqlite3 (1.4.2)
     thor (1.2.1)
     tzinfo (2.0.4)

--- a/gemfiles/rails_70.gemfile.lock
+++ b/gemfiles/rails_70.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     seamless_database_pool (1.0.20)
       activerecord (>= 3.2.0)
       concurrent-ruby (~> 1.0)
+      ruby2_keywords (>= 0.0.5)
 
 GEM
   remote: https://rubygems.org/
@@ -43,6 +44,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
     rspec-support (3.11.0)
+    ruby2_keywords (0.0.5)
     sqlite3 (1.4.2)
     thor (1.2.1)
     tzinfo (2.0.4)

--- a/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
+++ b/lib/active_record/connection_adapters/seamless_database_pool_adapter.rb
@@ -14,9 +14,9 @@ module ActiveRecord
         establish_adapter(master_config[:adapter])
         master_connection = send("#{master_config[:adapter]}_connection".to_sym, master_config)
         pool_weights[master_connection] = master_config[:pool_weight].to_i if master_config[:pool_weight].to_i > 0
-        
+
         SeamlessDatabasePool.connection_names[master_connection.object_id] = 'master'
-        
+
         read_connections = []
         config[:read_pool].each_with_index do |read_config, i|
           read_config = default_config.merge(read_config).with_indifferent_access
@@ -44,7 +44,7 @@ module ActiveRecord
       def establish_adapter(adapter)
         raise AdapterNotSpecified.new("database configuration does not specify adapter") unless adapter
         raise AdapterNotFound.new("database pool must specify adapters") if adapter == 'seamless_database_pool'
-      
+
         begin
           require 'rubygems'
           gem "activerecord-#{adapter}-adapter"
@@ -63,9 +63,9 @@ module ActiveRecord
         end
       end
     end
-    
+
     module SeamlessDatabasePoolBehavior
-      
+
       # Force reload to use the master connection since it's probably being called for a reason.
       def reload(*args)
         SeamlessDatabasePool.use_master_connection do
@@ -73,25 +73,25 @@ module ActiveRecord
         end
       end
     end
-    
+
     prepend SeamlessDatabasePoolBehavior
   end
 
   module ConnectionAdapters
     class SeamlessDatabasePoolAdapter < AbstractAdapter
-      
+
       attr_reader :read_connections, :master_connection
-      
+
       class << self
         # Create an anonymous class that extends this one and proxies methods to the pool connections.
         def adapter_class(master_connection)
           adapter_class_name = master_connection.adapter_name.classify
           return const_get(adapter_class_name) if const_defined?(adapter_class_name, false)
-          
+
           # Define methods to proxy to the appropriate pool
           read_only_methods = [:select, :select_rows, :execute, :tables, :columns]
           clear_cache_methods = [:insert, :update, :delete]
-          
+
           # Get a list of all methods redefined by the underlying adapter. These will be
           # proxied to the master connection.
           master_methods = []
@@ -117,7 +117,7 @@ module ActiveRecord
               end
             EOS
           end
-          
+
           clear_cache_methods.each do |method_name|
             klass.class_eval <<-EOS, __FILE__, __LINE__ + 1
               def #{method_name}(*args, &block)
@@ -128,7 +128,7 @@ module ActiveRecord
               end
             EOS
           end
-          
+
           read_only_methods.each do |method_name|
             klass.class_eval <<-EOS, __FILE__, __LINE__ + 1
               def #{method_name}(*args, &block)
@@ -140,10 +140,10 @@ module ActiveRecord
           klass.send :protected, :select
 
           const_set(adapter_class_name, klass)
-          
+
           return klass
         end
-      
+
         # Set the arel visitor on the connections.
         def visitor_for(pool)
           # This is ugly, but then again, so is the code in ActiveRecord for setting the arel
@@ -153,11 +153,12 @@ module ActiveRecord
           SeamlessDatabasePool.adapter_class_for(adapter).visitor_for(pool)
         end
       end
-      
+
       def initialize(connection, logger, master_connection, read_connections, pool_weights, config)
         @master_connection = master_connection
         @read_connections = read_connections.dup.freeze
-        
+        @use_master = nil
+
         super(connection, logger, config)
 
         @weighted_read_connections = []
@@ -166,38 +167,38 @@ module ActiveRecord
         end
         @available_read_connections = [AvailableConnections.new(@weighted_read_connections)]
       end
-      
+
       def adapter_name #:nodoc:
         'Seamless_Database_Pool'
       end
-      
+
       # Returns an array of the master connection and the read pool connections
       def all_connections
         [@master_connection] + @read_connections
       end
-      
+
       # Get the pool weight of a connection
       def pool_weight(connection)
         return @weighted_read_connections.select{|conn| conn == connection}.size
       end
-      
+
       def requires_reloading?
         false
       end
-      
+
       def transaction(options = {})
         SeamlessDatabasePool.use_master_connection
         super
       end
-      
+
       def visitor=(visitor)
         all_connections.each{|conn| conn.visitor = visitor}
       end
-      
+
       def visitor
         master_connection.visitor
       end
-      
+
       def active?
         if SeamlessDatabasePool.read_only_connection_type == :master
           @master_connection.active?
@@ -235,7 +236,7 @@ module ActiveRecord
         do_to_connections {|conn| total += conn.reset_runtime}
         total
       end
-      
+
       # Get a random read connection from the pool. If the connection is not active, it will attempt to reconnect
       # to the database. If that fails, it will be removed from the pool for one minute.
       def random_read_connection
@@ -246,16 +247,16 @@ module ActiveRecord
           weighted_read_connections[rand(weighted_read_connections.length)]
         end
       end
-      
+
       # Get the current read connection
       def current_read_connection
         return SeamlessDatabasePool.read_only_connection(self)
       end
-      
+
       def using_master_connection?
         !!@use_master
       end
-      
+
       # Force using the master connection in a block.
       def use_master_connection
         save_val = @use_master
@@ -266,30 +267,30 @@ module ActiveRecord
           @use_master = save_val
         end
       end
-      
+
       def to_s
         "#<#{self.class.name}:0x#{object_id.to_s(16)} #{all_connections.size} connections>"
       end
-      
+
       def inspect
         to_s
       end
-      
+
       class DatabaseConnectionError < StandardError
       end
-      
+
       # This simple class puts an expire time on an array of connections. It is used so the a connection
       # to a down database won't try to reconnect over and over.
       class AvailableConnections
         attr_reader :connections, :failed_connection
         attr_writer :expires
-        
+
         def initialize(connections, failed_connection = nil, expires = nil)
           @connections = connections
           @failed_connection = failed_connection
           @expires = expires
         end
-        
+
         def expired?
           @expires ? @expires <= Time.now : false
         end
@@ -299,7 +300,7 @@ module ActiveRecord
           raise DatabaseConnectionError.new unless failed_connection.active?
         end
       end
-      
+
       # Get the available weighted connections. When a connection is dead and cannot be reconnected, it will
       # be temporarily removed from the read pool so we don't keep trying to reconnect to a database that isn't
       # listening.
@@ -318,18 +319,18 @@ module ActiveRecord
             available.expires = 30.seconds.from_now
             return available.connections
           end
-          
+
           # If reconnect is successful, the connection will have been re-added to @available_read_connections list,
           # so let's pop this old version of the connection
           @available_read_connections.pop
-          
+
           # Now we'll try again after either expiring our bad connection or re-adding our good one
           return available_read_connections
         else
           return available.connections
         end
       end
-      
+
       def reset_available_read_connections
         @available_read_connections.slice!(1, @available_read_connections.length)
         @available_read_connections.first.connections.each do |connection|
@@ -338,7 +339,7 @@ module ActiveRecord
           end
         end
       end
-      
+
       # Temporarily remove a connection from the read pool.
       def suppress_read_connection(conn, expire)
         available = available_read_connections
@@ -358,9 +359,9 @@ module ActiveRecord
           @available_read_connections.push(AvailableConnections.new(connections, conn, expire.seconds.from_now))
         end
       end
-      
+
       private
-      
+
       def proxy_connection_method(connection, method, proxy_type, *args, &block)
         begin
           connection.send(method, *args, &block)

--- a/lib/seamless_database_pool.rb
+++ b/lib/seamless_database_pool.rb
@@ -19,12 +19,12 @@ $LOAD_PATH << File.dirname(__FILE__) unless $LOAD_PATH.include?(File.dirname(__F
 # read connection type. If none is ever called, the read connection type will be :master.
 
 module SeamlessDatabasePool
-    
+
   # Adapter name to class name map. This exists because there isn't an obvious way to translate things like
   # sqlite3 to SQLite3. The adapters that ship with ActiveRecord are defined here. If you use
   # an adapter that doesn't translate directly to camel case, then add the mapping here in an initializer.
   ADAPTER_TO_CLASS_NAME_MAP = {"sqlite" => "SQLite", "sqlite3" => "SQLite3", "postgresql" => "PostgreSQL"}
-  
+
   READ_CONNECTION_METHODS = [:master, :persistent, :random]
 
   # Map of `connection.object_id => connection_name`.
@@ -34,7 +34,7 @@ module SeamlessDatabasePool
 
   class << self
     attr_reader :connection_names
-    
+
     # Call this method to use a random connection from the read pool for every select statement.
     # This method is good if your replication is very fast. Otherwise there is a chance you could
     # get inconsistent results from one request to the next. This can result in mysterious failures
@@ -49,7 +49,7 @@ module SeamlessDatabasePool
         Thread.current[:read_only_connection] = :random
       end
     end
-  
+
     # Call this method to pick a random connection from the read pool and use it for all subsequent
     # select statements. This provides consistency from one select statement to the next. This
     # method should always be called with a block otherwise you can end up with an imbalanced read
@@ -63,7 +63,7 @@ module SeamlessDatabasePool
         Thread.current[:read_only_connection] = {}
       end
     end
-  
+
     # Call this method to use the master connection for all subsequent select statements. This
     # method is most useful when you are doing lots of updates since it guarantees consistency
     # if you do a select immediately after an update or insert.
@@ -77,7 +77,7 @@ module SeamlessDatabasePool
         Thread.current[:read_only_connection] = :master
       end
     end
-  
+
     # Set the read only connection type to either :master, :random, or :persistent.
     def set_read_only_connection_type(connection_type)
       saved_connection = Thread.current[:read_only_connection]
@@ -91,19 +91,19 @@ module SeamlessDatabasePool
       end
       return retval
     end
-  
+
     # Get the read only connection type currently in use. Will be one of :master, :random, or :persistent.
     def read_only_connection_type(default = :master)
       connection_type = Thread.current[:read_only_connection] || default
       connection_type = :persistent if connection_type.kind_of?(Hash)
       return connection_type
     end
-  
+
     # Get a read only connection from a connection pool.
     def read_only_connection(pool_connection)
       return pool_connection.master_connection if pool_connection.using_master_connection?
       connection_type = Thread.current[:read_only_connection]
-    
+
       if connection_type.kind_of?(Hash)
         connection = connection_type[pool_connection]
         unless connection
@@ -117,17 +117,17 @@ module SeamlessDatabasePool
         return pool_connection.master_connection
       end
     end
-  
+
     # This method is provided as a way to change the persistent connection when it fails and a new one is substituted.
     def set_persistent_read_connection(pool_connection, read_connection)
       connection_type = Thread.current[:read_only_connection]
       connection_type[pool_connection] = read_connection if connection_type.kind_of?(Hash)
     end
-  
+
     def clear_read_only_connection
       Thread.current[:read_only_connection] = nil
     end
-    
+
     # Get the connection adapter class for an adapter name. The class will be loaded from
     # ActiveRecord::ConnectionAdapters::NameAdapter where Name is the camelized version of the name.
     # If the adapter class does not fit this pattern (i.e. sqlite3 => SQLite3Adapter), then add
@@ -137,7 +137,7 @@ module SeamlessDatabasePool
       class_name = ADAPTER_TO_CLASS_NAME_MAP[name] || name.camelize
       "ActiveRecord::ConnectionAdapters::#{class_name}Adapter".constantize
     end
-    
+
     # Pull out the master configuration for compatibility with such things as the Rails' rake db:*
     # tasks which only support known adapters.
     def master_database_configuration(database_configs)

--- a/lib/seamless_database_pool/connection_statistics.rb
+++ b/lib/seamless_database_pool/connection_statistics.rb
@@ -39,7 +39,7 @@ module SeamlessDatabasePool
     end
 
     def increment_connection_statistic(method)
-      if @counting_pool_statistics
+      if defined?(@counting_pool_statistics) && @counting_pool_statistics
         yield
       else
         begin

--- a/lib/seamless_database_pool/controller_filter.rb
+++ b/lib/seamless_database_pool/controller_filter.rb
@@ -23,9 +23,8 @@ module SeamlessDatabasePool
 
     module ClassMethods
       def seamless_database_pool_options
-        return @seamless_database_pool_options if @seamless_database_pool_options
-        @seamless_database_pool_options = superclass.seamless_database_pool_options.dup if superclass.respond_to?(:seamless_database_pool_options)
-        @seamless_database_pool_options ||= {}
+        @seamless_database_pool_options ||= superclass.respond_to?(:seamless_database_pool_options) &&
+                                            superclass.seamless_database_pool_options.dup || {}
       end
 
       # Call this method to set up the connection types that will be used for your actions.

--- a/lib/seamless_database_pool/simple_controller_filter.rb
+++ b/lib/seamless_database_pool/simple_controller_filter.rb
@@ -41,7 +41,7 @@ module SeamlessDatabasePool
     end
 
     protected
-    
+
     def redirect_to(*)
       if SeamlessDatabasePool.read_only_connection_type(nil) == :master
         use_master_db_connection_on_next_request

--- a/seamless_database_pool.gemspec
+++ b/seamless_database_pool.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency("activerecord", [">= 3.2.0"])
   spec.add_runtime_dependency("concurrent-ruby", ["~> 1.0"])
+  spec.add_runtime_dependency("ruby2_keywords", [">= 0.0.5"]) # for ruby 2.6
 
   spec.add_development_dependency(%q<rspec>, [">= 2.0"])
   spec.add_development_dependency(%q<sqlite3>, [">= 0"])

--- a/spec/connection_adapters_spec.rb
+++ b/spec/connection_adapters_spec.rb
@@ -40,46 +40,46 @@ describe "Test connection adapters" do
 
         it "should force the master connection on reload" do
           record = model.first
-          SeamlessDatabasePool.should_not_receive(:current_read_connection)
+          expect(SeamlessDatabasePool).not_to receive(:current_read_connection)
           record.reload
         end
 
         it "should quote table names properly" do
-          connection.quote_table_name("foo").should == master_connection.quote_table_name("foo")
+          expect(connection.quote_table_name("foo")).to eq master_connection.quote_table_name("foo")
         end
 
         it "should quote column names properly" do
-          connection.quote_column_name("foo").should == master_connection.quote_column_name("foo")
+          expect(connection.quote_column_name("foo")).to eq master_connection.quote_column_name("foo")
         end
 
         it "should quote string properly" do
-          connection.quote_string("foo").should == master_connection.quote_string("foo")
+          expect(connection.quote_string("foo")).to eq master_connection.quote_string("foo")
         end
 
         it "should quote booleans properly" do
-          connection.quoted_true.should == master_connection.quoted_true
-          connection.quoted_false.should == master_connection.quoted_false
+          expect(connection.quoted_true).to eq master_connection.quoted_true
+          expect(connection.quoted_false).to eq master_connection.quoted_false
         end
 
         it "should quote dates properly" do
           date = Date.today
           time = Time.now
-          connection.quoted_date(date).should == master_connection.quoted_date(date)
-          connection.quoted_date(time).should == master_connection.quoted_date(time)
+          expect(connection.quoted_date(date)).to eq master_connection.quoted_date(date)
+          expect(connection.quoted_date(time)).to eq master_connection.quoted_date(time)
         end
 
         it "should query for records" do
           record = model.find_by_name("test")
-          record.name.should == "test"
+          expect(record.name).to eq "test"
         end
 
         it "should work with query caching" do
           record_id =  model.first.id
           model.cache do
             found = model.find(record_id)
-            found.value.should == 1
+            expect(found.value).to eq 1
             connection.master_connection.update("UPDATE #{model.table_name} SET value = 0 WHERE id = #{record_id}")
-            model.find(record_id).value.should == 1
+            expect(model.find(record_id).value).to eq 1
           end
         end
 
@@ -89,7 +89,7 @@ describe "Test connection adapters" do
             found = model.find(record_id)
             found.name = "new value"
             found.save!
-            model.find(record_id).name.should == "new value"
+            expect(model.find(record_id).name).to eq "new value"
           end
         end
 
@@ -97,50 +97,50 @@ describe "Test connection adapters" do
           let(:sample_sql){"SELECT #{connection.quote_column_name('name')} FROM #{connection.quote_table_name(model.table_name)}"}
 
           it "should not include the master connection in the read pool for these tests" do
-            connection.available_read_connections.should_not include(master_connection)
-            connection.current_read_connection.should_not == master_connection
+            expect(connection.available_read_connections).not_to include(master_connection)
+            expect(connection.current_read_connection).not_to eq master_connection
           end
 
           it "should send select to the read connection" do
             results = connection.send(:select, sample_sql)
-            results.to_a.should == [{"name" => "test"}]
-            results.to_a.should == master_connection.send(:select, sample_sql).to_a
-            results.should be_read_only
+            expect(results.to_a).to eq [{"name" => "test"}]
+            expect(results.to_a).to eq master_connection.send(:select, sample_sql).to_a
+            expect(results).to be_read_only
           end
 
           it "should send select_rows to the read connection" do
             results = connection.select_rows(sample_sql)
-            results.should == [["test"]]
-            results.should == master_connection.select_rows(sample_sql)
-            results.should be_read_only
+            expect(results).to eq [["test"]]
+            expect(results).to eq master_connection.select_rows(sample_sql)
+            expect(results).to be_read_only
           end
 
           it "should send execute to the read connection" do
             results = connection.execute(sample_sql)
-            results.should be_read_only
+            expect(results).to be_read_only
           end
 
           it "should send columns to the read connection" do
             results = connection.columns(model.table_name)
             columns = results.collect{|c| c.name}.sort.should
-            columns.should == ["id", "name", "value"]
-            columns.should == master_connection.columns(model.table_name).collect{|c| c.name}.sort
-            results.should be_read_only
+            expect(columns).to eq ["id", "name", "value"]
+            expect(columns).to eq master_connection.columns(model.table_name).collect{|c| c.name}.sort
+            expect(results).to be_read_only
           end
 
           it "should send tables to the read connection" do
             results = connection.tables
-            results.should == [model.table_name]
-            results.should == master_connection.tables
-            results.should be_read_only
+            expect(results).to eq [model.table_name]
+            expect(results).to eq master_connection.tables
+            expect(results).to be_read_only
           end
 
           it "should reconnect dead connections in the read pool" do
             read_connection.disconnect!
-            read_connection.should_not be_active
+            expect(read_connection).not_to be_active
             results = connection.select_all(sample_sql)
-            results.should be_read_only
-            read_connection.should be_active
+            expect(results).to be_read_only
+            expect(read_connection).to be_active
           end
         end
 
@@ -149,26 +149,26 @@ describe "Test connection adapters" do
 
           it "should use select_all" do
             results = connection.select_all(sample_sql)
-            results.to_a.should == [{"name" => "test"}].to_a
-            results.to_a.should == master_connection.select_all(sample_sql).to_a
+            expect(results.to_a).to eq [{"name" => "test"}].to_a
+            expect(results.to_a).to eq master_connection.select_all(sample_sql).to_a
           end
 
           it "should use select_one" do
             results = connection.select_one(sample_sql)
-            results.should == {"name" => "test"}
-            results.should == master_connection.select_one(sample_sql)
+            expect(results).to eq({"name" => "test"})
+            expect(results).to eq master_connection.select_one(sample_sql)
           end
 
           it "should use select_values" do
             results = connection.select_values(sample_sql)
-            results.should == ["test"]
-            results.should == master_connection.select_values(sample_sql)
+            expect(results).to eq ["test"]
+            expect(results).to eq master_connection.select_values(sample_sql)
           end
 
           it "should use select_value" do
             results = connection.select_value(sample_sql)
-            results.should == "test"
-            results.should == master_connection.select_value(sample_sql)
+            expect(results).to eq "test"
+            expect(results).to eq master_connection.select_value(sample_sql)
           end
         end
 
@@ -178,33 +178,33 @@ describe "Test connection adapters" do
           let(:delete_sql){ "DELETE FROM #{connection.quote_table_name(model.table_name)}" }
 
           it "should blow up if a master connection method is sent to the read only connection" do
-            lambda{read_connection.update(update_sql)}.should raise_error(NotImplementedError)
-            lambda{read_connection.update(insert_sql)}.should raise_error(NotImplementedError)
-            lambda{read_connection.update(delete_sql)}.should raise_error(NotImplementedError)
-            lambda{read_connection.transaction{}}.should raise_error(NotImplementedError)
-            lambda{read_connection.create_table(:test)}.should raise_error(NotImplementedError)
+            expect { read_connection.update(update_sql)  }.to raise_error(NotImplementedError)
+            expect { read_connection.update(insert_sql)  }.to raise_error(NotImplementedError)
+            expect { read_connection.update(delete_sql)  }.to raise_error(NotImplementedError)
+            expect { read_connection.transaction{}       }.to raise_error(NotImplementedError)
+            expect { read_connection.create_table(:test) }.to raise_error(NotImplementedError)
           end
 
           it "should send update to the master connection" do
             connection.update(update_sql)
-            model.first.value.should == 2
+            expect(model.first.value).to eq 2
           end
 
           it "should send insert to the master connection" do
             connection.update(insert_sql)
-            model.find_by_name("new").should_not == nil
+            expect(model.find_by_name("new")).not_to eq nil
           end
 
           it "should send delete to the master connection" do
             connection.update(delete_sql)
-            model.first.should == nil
+            expect(model.first).to eq nil
           end
 
           it "should send transaction to the master connection" do
             connection.transaction do
               connection.update(update_sql)
             end
-            model.first.value.should == 2
+            expect(model.first.value).to eq 2
           end
 
           it "should send schema altering statements to the master connection" do
@@ -228,7 +228,7 @@ describe "Test connection adapters" do
             without_driver = StringIO.new
             ActiveRecord::SchemaDumper.dump(master_connection, without_driver)
 
-            with_driver.string.should == without_driver.string
+            expect(with_driver.string).to eq without_driver.string
           end
 
           it "should allow for database specific types" do 

--- a/spec/connection_statistics_spec.rb
+++ b/spec/connection_statistics_spec.rb
@@ -3,22 +3,22 @@ require 'spec_helper'
 describe SeamlessDatabasePool::ConnectionStatistics do
   module SeamlessDatabasePool
     class ConnectionStatisticsTester
-      def insert (sql, name = nil)
+      def insert(sql, name = nil)
         "INSERT #{sql}/#{name}"
       end
 
-      def update (sql, name = nil)
+      def update(sql, name = nil)
         execute(sql)
         "UPDATE #{sql}/#{name}"
       end
 
-      def execute (sql, name = nil)
+      def execute(sql, name = nil)
         "EXECUTE #{sql}/#{name}"
       end
 
       protected
 
-      def select (sql, name = nil, binds = [])
+      def select(sql, name = nil, binds = [])
         "SELECT #{sql}/#{name}"
       end
 
@@ -72,5 +72,4 @@ describe SeamlessDatabasePool::ConnectionStatistics do
     connection.reset_connection_statistics
     connection.connection_statistics.should == {}
   end
-
 end

--- a/spec/connection_statistics_spec.rb
+++ b/spec/connection_statistics_spec.rb
@@ -28,48 +28,48 @@ describe SeamlessDatabasePool::ConnectionStatistics do
 
   it "should increment statistics on update" do
     connection = SeamlessDatabasePool::ConnectionStatisticsTester.new
-    connection.update('SQL', 'name').should == "UPDATE SQL/name"
-    connection.connection_statistics.should == {:update => 1}
-    connection.update('SQL 2').should == "UPDATE SQL 2/"
-    connection.connection_statistics.should == {:update => 2}
+    expect(connection.update('SQL', 'name')).to eq "UPDATE SQL/name"
+    expect(connection.connection_statistics).to eq({:update => 1})
+    expect(connection.update('SQL 2')).to eq "UPDATE SQL 2/"
+    expect(connection.connection_statistics).to eq({:update => 2})
   end
 
   it "should increment statistics on insert" do
     connection = SeamlessDatabasePool::ConnectionStatisticsTester.new
-    connection.insert('SQL', 'name').should == "INSERT SQL/name"
-    connection.connection_statistics.should == {:insert => 1}
-    connection.insert('SQL 2').should == "INSERT SQL 2/"
-    connection.connection_statistics.should == {:insert => 2}
+    expect(connection.insert('SQL', 'name')).to eq "INSERT SQL/name"
+    expect(connection.connection_statistics).to eq({:insert => 1})
+    expect(connection.insert('SQL 2')).to eq "INSERT SQL 2/"
+    expect(connection.connection_statistics).to eq({:insert => 2})
   end
 
   it "should increment statistics on execute" do
     connection = SeamlessDatabasePool::ConnectionStatisticsTester.new
-    connection.execute('SQL', 'name').should == "EXECUTE SQL/name"
-    connection.connection_statistics.should == {:execute => 1}
-    connection.execute('SQL 2').should == "EXECUTE SQL 2/"
-    connection.connection_statistics.should == {:execute => 2}
+    expect(connection.execute('SQL', 'name')).to eq "EXECUTE SQL/name"
+    expect(connection.connection_statistics).to eq({:execute => 1})
+    expect(connection.execute('SQL 2')).to eq "EXECUTE SQL 2/"
+    expect(connection.connection_statistics).to eq({:execute => 2})
   end
 
   it "should increment statistics on select" do
     connection = SeamlessDatabasePool::ConnectionStatisticsTester.new
-    connection.send(:select, 'SQL', 'name').should == "SELECT SQL/name"
-    connection.connection_statistics.should == {:select => 1}
-    connection.send(:select, 'SQL 2').should == "SELECT SQL 2/"
-    connection.connection_statistics.should == {:select => 2}
+    expect(connection.send(:select, 'SQL', 'name')).to eq "SELECT SQL/name"
+    expect(connection.connection_statistics).to eq({:select => 1})
+    expect(connection.send(:select, 'SQL 2')).to eq "SELECT SQL 2/"
+    expect(connection.connection_statistics).to eq({:select => 2})
   end
 
   it "should increment counts only once within a block" do
     connection = SeamlessDatabasePool::ConnectionStatisticsTester.new
     expect(connection).to receive(:execute).with('SQL')
     connection.update('SQL')
-    connection.connection_statistics.should == {:update => 1}
+    expect(connection.connection_statistics).to eq({:update => 1})
   end
 
   it "should be able to clear the statistics" do
     connection = SeamlessDatabasePool::ConnectionStatisticsTester.new
     connection.update('SQL')
-    connection.connection_statistics.should == {:update => 1}
+    expect(connection.connection_statistics).to eq({:update => 1})
     connection.reset_connection_statistics
-    connection.connection_statistics.should == {}
+    expect(connection.connection_statistics).to eq({})
   end
 end

--- a/spec/controller_filter_spec.rb
+++ b/spec/controller_filter_spec.rb
@@ -88,63 +88,63 @@ describe "SeamlessDatabasePool::ControllerFilter" do
 
   it "should work with nothing set" do
     controller = SeamlessDatabasePool::TestApplicationController.new(session)
-    controller.process('base_action').should == :master
+    expect(controller.process('base_action')).to eq :master
   end
 
   it "should allow setting a connection type for a single action" do
     controller = SeamlessDatabasePool::TestBaseController.new(session)
-    controller.process('read').should == :persistent
+    expect(controller.process('read')).to eq :persistent
   end
 
   it "should allow setting a connection type for actions" do
-    controller.process('edit').should == :master
-    controller.process('save').should == :master
+    expect(controller.process('edit')).to eq :master
+    expect(controller.process('save')).to eq :master
   end
 
   it "should allow setting a connection type for all actions" do
-    controller.process('other').should == :random
+    expect(controller.process('other')).to eq :random
   end
 
   it "should inherit the superclass' options" do
-    controller.process('read').should == :persistent
+    expect(controller.process('read')).to eq :persistent
   end
 
   it "should be able to force using the master connection on the next request" do
     # First request
-    controller.process('read').should == :persistent
+    expect(controller.process('read')).to eq :persistent
     controller.use_master_db_connection_on_next_request
 
     # Second request
-    controller.process('read').should == :master
+    expect(controller.process('read')).to eq :master
 
     # Third request
-    controller.process('read').should == :persistent
+    expect(controller.process('read')).to eq :persistent
   end
 
   it "should not break trying to force the master connection if sessions are not enabled" do
-    controller.process('read').should == :persistent
+    expect(controller.process('read')).to eq :persistent
     controller.use_master_db_connection_on_next_request
 
     # Second request
     session.clear
-    controller.process('read').should == :persistent
+    expect(controller.process('read')).to eq :persistent
   end
 
   it "should force the master connection on the next request for a redirect in master connection block" do
     controller = SeamlessDatabasePool::TestOtherController.new(session)
-    controller.process('redirect_master_action').should == {:action => :read}
+    expect(controller.process('redirect_master_action')).to eq({:action => :read})
 
-    controller.process('read').should == :master
+    expect(controller.process('read')).to eq :master
   end
 
   it "should not force the master connection on the next request for a redirect not in master connection block" do
-    controller.process('redirect_read_action').should == {:action => :read}
+    expect(controller.process('redirect_read_action')).to eq({:action => :read})
 
-    controller.process('read').should == :persistent
+    expect(controller.process('read')).to eq :persistent
   end
 
   it "should work with a Rails 2 controller" do
     controller = SeamlessDatabasePool::TestRails2BaseController.new(session)
-    controller.process('read').should == :persistent
+    expect(controller.process('read')).to eq :persistent
   end
 end

--- a/spec/controller_filter_spec.rb
+++ b/spec/controller_filter_spec.rb
@@ -14,7 +14,7 @@ describe "SeamlessDatabasePool::ControllerFilter" do
         send action
       end
 
-      def redirect_to (options = {}, response_status = {})
+      def redirect_to(options = {}, response_status = {})
         options
       end
 

--- a/spec/seamless_database_pool_adapter_spec.rb
+++ b/spec/seamless_database_pool_adapter_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 module SeamlessDatabasePool
   class MockConnection < ActiveRecord::ConnectionAdapters::AbstractAdapter
-    def initialize (name)
+    def initialize(name)
       @name = name
     end
 
@@ -26,10 +26,10 @@ module SeamlessDatabasePool
   end
 
   class MockMasterConnection < MockConnection
-    def insert (sql, name = nil); end
-    def update (sql, name = nil); end
-    def execute (sql, name = nil); end
-    def columns (table_name, name = nil); end
+    def insert(sql, name = nil); end
+    def update(sql, name = nil); end
+    def execute(sql, name = nil); end
+    def columns(table_name, name = nil); end
   end
 end
 

--- a/spec/seamless_database_pool_spec.rb
+++ b/spec/seamless_database_pool_spec.rb
@@ -12,96 +12,96 @@ describe "SeamlessDatabasePool" do
 
   it "should use the master connection by default" do
     connection = double(:connection, :master_connection => :master_db_connection, :using_master_connection? => false)
-    SeamlessDatabasePool.read_only_connection_type.should == :master
-    SeamlessDatabasePool.read_only_connection(connection).should == :master_db_connection
+    expect(SeamlessDatabasePool.read_only_connection_type).to eq :master
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :master_db_connection
   end
 
   it "should be able to set using persistent read connections" do
     connection = double(:connection)
-    connection.should_receive(:random_read_connection).once.and_return(:read_db_connection)
-    connection.stub(:using_master_connection? => false)
+    expect(connection).to receive(:random_read_connection).once.and_return(:read_db_connection)
+    allow(connection).to receive(:using_master_connection?).and_return(false)
     SeamlessDatabasePool.use_persistent_read_connection
-    SeamlessDatabasePool.read_only_connection_type.should == :persistent
-    SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection
-    SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection
+    expect(SeamlessDatabasePool.read_only_connection_type).to eq :persistent
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection
   end
 
   it "should be able to set using random read connections" do
     connection = double(:connection)
-    connection.should_receive(:random_read_connection).and_return(:read_db_connection_1, :read_db_connection_2)
-    connection.stub(:using_master_connection? => false)
+    expect(connection).to receive(:random_read_connection).and_return(:read_db_connection_1, :read_db_connection_2)
+    allow(connection).to receive(:using_master_connection?).and_return(false)
     SeamlessDatabasePool.use_random_read_connection
-    SeamlessDatabasePool.read_only_connection_type.should == :random
-    SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection_1
-    SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection_2
+    expect(SeamlessDatabasePool.read_only_connection_type).to eq :random
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection_1
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection_2
   end
 
   it "should use the master connection if the connection is forcing it" do
     connection = double(:connection, :master_connection => :master_db_connection)
-    connection.should_receive(:using_master_connection?).and_return(true)
+    expect(connection).to receive(:using_master_connection?).and_return(true)
     SeamlessDatabasePool.use_persistent_read_connection
-    SeamlessDatabasePool.read_only_connection(connection).should == :master_db_connection
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :master_db_connection
   end
 
   it "should be able to set using the master connection" do
     connection = double(:connection, :master_connection => :master_db_connection)
-    connection.stub(:using_master_connection? => false)
+    allow(connection).to receive(:using_master_connection?).and_return(false)
     SeamlessDatabasePool.use_master_connection
-    SeamlessDatabasePool.read_only_connection(connection).should == :master_db_connection
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :master_db_connection
   end
 
   it "should be able to use persistent read connections within a block" do
     connection = double(:connection, :master_connection => :master_db_connection)
-    connection.should_receive(:random_read_connection).once.and_return(:read_db_connection)
-    connection.stub(:using_master_connection? => false)
-    SeamlessDatabasePool.read_only_connection(connection).should == :master_db_connection
-    SeamlessDatabasePool.use_persistent_read_connection do
-      SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection
-      SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection
+    expect(connection).to receive(:random_read_connection).once.and_return(:read_db_connection)
+    allow(connection).to receive(:using_master_connection?).and_return(false)
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :master_db_connection
+    expect(SeamlessDatabasePool.use_persistent_read_connection do
+      expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection
+      expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection
       :test_val
-    end.should == :test_val
-    SeamlessDatabasePool.read_only_connection(connection).should == :master_db_connection
+    end).to eq :test_val
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :master_db_connection
   end
 
   it "should be able to use random read connections within a block" do
     connection = double(:connection, :master_connection => :master_db_connection)
-    connection.should_receive(:random_read_connection).and_return(:read_db_connection_1, :read_db_connection_2)
-    connection.stub(:using_master_connection? => false)
-    SeamlessDatabasePool.read_only_connection(connection).should == :master_db_connection
-    SeamlessDatabasePool.use_random_read_connection do
-      SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection_1
-      SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection_2
+    expect(connection).to receive(:random_read_connection).and_return(:read_db_connection_1, :read_db_connection_2)
+    allow(connection).to receive(:using_master_connection?).and_return(false)
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :master_db_connection
+    expect(SeamlessDatabasePool.use_random_read_connection do
+      expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection_1
+      expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection_2
         :test_val
-      end.should == :test_val
-    SeamlessDatabasePool.read_only_connection(connection).should == :master_db_connection
+    end).to eq :test_val
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :master_db_connection
   end
 
   it "should be able to use the master connection within a block" do
     connection = double(:connection, :master_connection => :master_db_connection)
-    connection.should_receive(:random_read_connection).once.and_return(:read_db_connection)
-    connection.stub(:using_master_connection? => false)
+    expect(connection).to receive(:random_read_connection).once.and_return(:read_db_connection)
+    allow(connection).to receive(:using_master_connection?).and_return(false)
     SeamlessDatabasePool.use_persistent_read_connection
-    SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection
-    SeamlessDatabasePool.use_master_connection do
-      SeamlessDatabasePool.read_only_connection(connection).should == :master_db_connection
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection
+    expect(SeamlessDatabasePool.use_master_connection do
+      expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :master_db_connection
         :test_val
-      end.should == :test_val
-    SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection
+    end).to eq :test_val
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection
     SeamlessDatabasePool.clear_read_only_connection
   end
 
   it "should be able to use connection blocks within connection blocks" do
     connection = double(:connection, :master_connection => :master_db_connection)
-    connection.stub(:random_read_connection => :read_db_connection)
-    connection.stub(:using_master_connection? => false)
+    allow(connection).to receive(:random_read_connection).and_return(:read_db_connection)
+    allow(connection).to receive(:using_master_connection?).and_return(false)
     SeamlessDatabasePool.use_persistent_read_connection do
-      SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection
+      expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection
       SeamlessDatabasePool.use_master_connection do
-        SeamlessDatabasePool.read_only_connection(connection).should == :master_db_connection
+        expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :master_db_connection
         SeamlessDatabasePool.use_random_read_connection do
-          SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection
+          expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection
         end
-        SeamlessDatabasePool.read_only_connection(connection).should == :master_db_connection
+        expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :master_db_connection
       end
     end
     SeamlessDatabasePool.clear_read_only_connection
@@ -109,24 +109,25 @@ describe "SeamlessDatabasePool" do
 
   it "should be able to change the persistent connection" do
     connection = double(:connection)
-    connection.stub(:random_read_connection => :read_db_connection, :using_master_connection? => false)
+    allow(connection).to receive(:random_read_connection).and_return(:read_db_connection)
+    allow(connection).to receive(:using_master_connection?).and_return(false)
 
     SeamlessDatabasePool.use_persistent_read_connection
-    SeamlessDatabasePool.read_only_connection_type.should == :persistent
-    SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection
+    expect(SeamlessDatabasePool.read_only_connection_type).to eq :persistent
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection
     SeamlessDatabasePool.set_persistent_read_connection(connection, :another_db_connection)
-    SeamlessDatabasePool.read_only_connection(connection).should == :another_db_connection
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :another_db_connection
 
     SeamlessDatabasePool.use_random_read_connection
-    SeamlessDatabasePool.read_only_connection_type.should == :random
-    SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection
+    expect(SeamlessDatabasePool.read_only_connection_type).to eq :random
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection
     SeamlessDatabasePool.set_persistent_read_connection(connection, :another_db_connection)
-    SeamlessDatabasePool.read_only_connection(connection).should == :read_db_connection
+    expect(SeamlessDatabasePool.read_only_connection(connection)).to eq :read_db_connection
   end
 
   it "should be able to specify a default read connection type instead of :master" do
-    SeamlessDatabasePool.read_only_connection_type.should == :master
-    SeamlessDatabasePool.read_only_connection_type(nil).should == nil
+    expect(SeamlessDatabasePool.read_only_connection_type).to eq :master
+    expect(SeamlessDatabasePool.read_only_connection_type(nil)).to eq nil
   end
 
   it "should pull out the master configurations for compatibility with rake db:* tasks" do
@@ -150,7 +151,7 @@ describe "SeamlessDatabasePool" do
         'database' => 'test'
       }
     }
-    SeamlessDatabasePool.master_database_configuration(config).should == {
+    expect(SeamlessDatabasePool.master_database_configuration(config)).to eq({
       'development' => {
         'adapter' => 'mysql2',
         'database' => 'development',
@@ -161,6 +162,6 @@ describe "SeamlessDatabasePool" do
         'adapter' => 'mysql2',
         'database' => 'test'
       }
-    }
+    })
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,7 @@ active_record_version = [active_record_version] unless active_record_version.is_
 gem 'activerecord', *active_record_version
 
 require 'active_record'
-puts "Testing Against ActiveRecord #{ActiveRecord::VERSION::STRING}" if defined?(ActiveRecord::VERSION)
+puts "Testing Against ActiveRecord #{ActiveRecord::VERSION::STRING} on Ruby #{RUBY_VERSION}" if defined?(ActiveRecord::VERSION)
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'seamless_database_pool'))
 require File.expand_path(File.join(File.dirname(__FILE__), 'test_model'))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,3 +24,9 @@ RSpec.configure do |config|
   config.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
   config.mock_with(:rspec) { |c| c.syntax = [:should, :expect] }
 end
+
+# enable ruby 2.7 warnings
+if defined?(Warning) && Warning.respond_to?(:[]=)
+  $VERBOSE = true
+  Warning[:deprecated] = true
+end

--- a/spec/test_adapter/active_record/connection_adapters/read_only_adapter.rb
+++ b/spec/test_adapter/active_record/connection_adapters/read_only_adapter.rb
@@ -11,7 +11,7 @@ module ActiveRecord
     class ReadOnlyAdapter < AbstractAdapter
       %w(select select_rows execute tables columns).each do |read_method|
         class_eval <<-EOS, __FILE__, __LINE__ + 1
-          def #{read_method}(*args, &block)
+          ruby2_keywords def #{read_method}(*args, &block)
             raise "Not Connected" unless @connected
             result = @connection.send(:#{read_method}, *args, &block)
             def result.read_only?
@@ -24,7 +24,7 @@ module ActiveRecord
 
       %w(update insert delete reload create_table drop_table add_index remove_index transaction).each do |write_method|
         class_eval <<-EOS, __FILE__, __LINE__ + 1
-          def #{write_method}(*args, &block)
+          def #{write_method}(*args, **kwargs, &block)
             raise NotImplementedError.new("Master method '#{write_method}' called on read only connection")
           end
         EOS

--- a/spec/test_adapter/active_record/connection_adapters/read_only_adapter.rb
+++ b/spec/test_adapter/active_record/connection_adapters/read_only_adapter.rb
@@ -20,14 +20,14 @@ module ActiveRecord
             result
           end
         EOS
+      end
 
-        %w(update insert delete reload create_table drop_table add_index remove_index transaction).each do |write_method|
-          class_eval <<-EOS, __FILE__, __LINE__ + 1
-            def #{write_method}(*args, &block)
-              raise NotImplementedError.new("Master method '#{write_method}' called on read only connection")
-            end
-          EOS
-        end
+      %w(update insert delete reload create_table drop_table add_index remove_index transaction).each do |write_method|
+        class_eval <<-EOS, __FILE__, __LINE__ + 1
+          def #{write_method}(*args, &block)
+            raise NotImplementedError.new("Master method '#{write_method}' called on read only connection")
+          end
+        EOS
       end
 
       def initialize(connection)

--- a/spec/test_adapter/active_record/connection_adapters/read_only_adapter.rb
+++ b/spec/test_adapter/active_record/connection_adapters/read_only_adapter.rb
@@ -11,7 +11,7 @@ module ActiveRecord
     class ReadOnlyAdapter < AbstractAdapter
       %w(select select_rows execute tables columns).each do |read_method|
         class_eval <<-EOS, __FILE__, __LINE__ + 1
-          def #{read_method} (*args, &block)
+          def #{read_method}(*args, &block)
             raise "Not Connected" unless @connected
             result = @connection.send(:#{read_method}, *args, &block)
             def result.read_only?
@@ -23,7 +23,7 @@ module ActiveRecord
 
         %w(update insert delete reload create_table drop_table add_index remove_index transaction).each do |write_method|
           class_eval <<-EOS, __FILE__, __LINE__ + 1
-            def #{write_method} (*args, &block)
+            def #{write_method}(*args, &block)
               raise NotImplementedError.new("Master method '#{write_method}' called on read only connection")
             end
           EOS


### PR DESCRIPTION
- Enable ruby warnings in tests
- Fix whitespace and some uninitialized instance variables
- Fix unnecessary method redefinition
- Use rspec expect syntax
- Fix ruby 2.7 kwargs
