### PR TITLE
При сборе конфигов БД используем флаг include_hidden: true

### DIFF
--- a/lib/seamless_database_pool.rb
+++ b/lib/seamless_database_pool.rb
@@ -141,7 +141,9 @@ module SeamlessDatabasePool
     # Pull out the master configuration for compatibility with such things as the Rails' rake db:*
     # tasks which only support known adapters.
     def master_database_configuration(database_configs)
-      database_configs = database_configs.configs_for.map do |conf|
+      # will only work for rails 6.1 and higher as for the time of writing 6.1 is the "youngest" supported
+      configs_attributes = Rails::VERSION::MAJOR < 7 ? { include_replicas: true } : { include_hidden: true }
+      database_configs = database_configs.configs_for(**configs_attributes).map do |conf|
         next conf unless conf.adapter == 'seamless_database_pool'
 
         new_conf = conf.configuration_hash.symbolize_keys

--- a/spec/seamless_database_pool_spec.rb
+++ b/spec/seamless_database_pool_spec.rb
@@ -210,7 +210,7 @@ describe 'SeamlessDatabasePool' do
 
       it 'should pull out the master configurations for compatibility with rake db:* tasks' do
         expect(master_database_configuration).to be_a(ActiveRecord::DatabaseConfigurations)
-        expect(master_database_configuration.configurations.size).to eq(4) # except replica
+        expect(master_database_configuration.configurations.size).to eq(5)
 
         expect(master_database_configuration.configs_for(env_name: 'development').map(&:configuration_hash)).to eq(
           [


### PR DESCRIPTION
Для мультибазовости рельсы добавили флажок `include_hidden: false` (на самом деле, там есть ещё про реплики, но его депрекейтят в 7.1 в пользу вышеупомянутого). Если его не передать, он вырезает реплики. Получалось, что они теряются из-за того, что гем стар.